### PR TITLE
Added option for formatting and arbitrary metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ logger.info('Hello %s!', 'world');
 
 - `createLoggers()` takes a minimum logging `level`, which is one of: `['info', 'warn', 'error']` and defaults to `info`. For example if you select `warn`, all `info` logs will be ignored. `warn` and `error` logs will be displayed.
 
+Support for formatting and arbitrary metadata
+```js
+import createLoggers from 'namespaced-console-logger';
+
+const loggers = createLoggers('info', '${timestamp} ${hostname} (${namespace}) ${level}:', { hostname: 'machinename' });
+const logger = loggers.get('namespace');
+
+//2015-08-10T20:09:20.526Z machinename (namespace) INFO: Hello world!
+logger.info('Hello %s!', 'world');
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Support for formatting and arbitrary metadata
 ```js
 import createLoggers from 'namespaced-console-logger';
 
-const loggers = createLoggers('info', '${timestamp} ${hostname} (${namespace}) ${level}:', { hostname: 'machinename' });
+const loggers = createLoggers('info', '{{timestamp}} {{hostname}} {{calculatedValue}} ({{namespace}}) {{level}}:', { hostname: 'machinename', calculatedValue: () =>  { return 1 + 2; } });
 const logger = loggers.get('namespace');
 
-//2015-08-10T20:09:20.526Z machinename (namespace) INFO: Hello world!
+//2015-08-10T20:09:20.526Z machinename 3 (namespace) INFO: Hello world!
 logger.info('Hello %s!', 'world');
 ```
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "babel": "^5.6.23",
     "babel-eslint": "^4.1.8",
-+   "eslint": "^1.10.3",
+    "eslint": "^1.10.3",
     "istanbul": "^0.3.17",
     "mocha": "^2.2.5",
     "should": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "dependencies": {},
   "devDependencies": {
     "babel": "^5.6.23",
-    "babel-eslint": "^3.1.23",
-    "eslint": "^0.24.1",
+    "babel-eslint": "^4.1.8",
++   "eslint": "^1.10.3",
     "istanbul": "^0.3.17",
     "mocha": "^2.2.5",
     "should": "^7.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import template from './template'
+
 /* eslint no-console: 0 */
 const slice = Array.prototype.slice;
 const allLevels = ['error', 'warn', 'info'];
@@ -7,32 +9,38 @@ const allLevels = ['error', 'warn', 'info'];
  * logging level of `info`.
  *
  * @param {String} level (info|warn|error) minimum logging level
+ * @param {String} format format meta data
+ * @param {Object} data meta data
  */
 
-export default function (level = 'info') {
+export default function (level = 'info', format, data) {
+  format = format || '${timestamp} (${namespace}) ${level}:';
+  data = data || {};
+  const parsed = template.parse(format);
   const levelIndex = allLevels.indexOf(level) + 1;
   const get = createGet(
     allLevels.slice(0, levelIndex),
-    allLevels.slice(levelIndex));
+    allLevels.slice(levelIndex),
+    parsed,
+    data);
   return {get};
 }
 
-function createGet(enabled, disabled) {
+function createGet(enabled, disabled, parsed, data) {
   return function (namespace) {
     const logger = {};
-    enabled.forEach(level => logger[level] = create(namespace, level));
+    enabled.forEach(level => logger[level] = create(namespace, level, parsed, data));
     disabled.forEach(level => logger[level] = noop);
     return logger;
   };
 }
 
-function create(namespace, level) {
+function create(namespace, level, parsed, data) {
   return function () {
-    const prefix = [
-      new Date().toISOString(),
-      '(' + namespace + ')',
-      level.toUpperCase()
-    ].join(' ') + ':';
+    data.namespace = namespace;
+    data.level = level.toUpperCase();
+    data.timestamp = new Date().toISOString();
+    const prefix = template.resolve(parsed, data);
     const args = slice.call(arguments);
     if (typeof args[0] === 'string') args[0] = prefix + ' ' + args[0];
     else args.unshift(prefix);

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const allLevels = ['error', 'warn', 'info'];
  */
 
 export default function (level = 'info', format, meta) {
-  format = format || '${timestamp} (${namespace}) ${level}:';
+  format = format || '{{timestamp}} ({{namespace}}) {{level}}:';
   meta = meta || {};
   const compiledFunc = template(format);
   const levelIndex = allLevels.indexOf(level) + 1;

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const allLevels = ['error', 'warn', 'info'];
 export default function (level = 'info', format, meta) {
   format = format || '{{timestamp}} ({{namespace}}) {{level}}:';
   meta = meta || {};
-  const compiledFunc = template(format);
+  const compiledFunc = template(format, meta);
   const levelIndex = allLevels.indexOf(level) + 1;
   const get = createGet(
     allLevels.slice(0, levelIndex),

--- a/src/template.js
+++ b/src/template.js
@@ -1,0 +1,44 @@
+/**
+ * Parse format string and return object
+ *
+ * @param {String} format format string
+ */
+exports.parse = function (format) {
+  let regex = /\$\{(\w+)\}/g;
+  let result = [];
+
+  let index = 0;
+  let length = 0;
+  let match;
+  while (match = regex.exec(format)) {
+    if (index + length < match.index) {
+      result.push({type: 'text', value: format.substring(index + length, match.index)});
+    }
+    result.push({type: 'key', key: match[1], value: match[0]});
+
+    index = match.index;
+    length = match[0].length;
+  }
+  if ((index + length) < format.length) {
+    result.push({type: 'text', value: format.substring(index + length, format.length)});
+  }
+  return result;
+}
+
+/**
+ * Parse format string and return object
+ *
+ * @param {String} parsed parsed format string
+ * @param {Object} data metadata
+ */
+exports.resolve = function (parsed, data) {
+  let result = '';
+  parsed.forEach(function (el) {
+    if (el.type === 'key') {
+      result += data[el.key] || el.value;
+    } else {
+      result += el.value;
+    }
+  });
+  return result;
+}

--- a/src/template.js
+++ b/src/template.js
@@ -4,8 +4,12 @@
  * @param {String} format format string
  */
 export default function (format) {
-  let regex = /\$\{(\w+)\}/g;
-  let result = [];
+  const regex = /\{\{(\w+)\}\}/g;
+  const result = [];
+
+  if (!format || (typeof format !== 'string' &&  !(format instanceof String))) {
+    return new Function('data', 'return \'\';');
+  }
 
   let index = 0;
   let length = 0;
@@ -14,7 +18,8 @@ export default function (format) {
     if (index + length < match.index) {
       result.push('\'' + format.substring(index + length, match.index) + '\'');
     }
-    result.push('(data.' + match[1] + ' || \'' + match[0] + '\')');
+    //fast check for a function: !!(object && object.constructor && object.call && object.apply) 
+    result.push('((!!(data.' + match[1] + ' && data.' + match[1] + '.constructor && data.' + match[1] + '.call && data.' + match[1] + '.apply) ? data.' + match[1] + '() : data.' + match[1] + ') || \'' + match[0] + '\')');
 
     index = match.index;
     length = match[0].length;
@@ -23,6 +28,6 @@ export default function (format) {
     result.push('\'' + format.substring(index + length, format.length) + '\'');
   }
 
-  let funcBody = 'return ' + result.join(' + ') + ';';
+  const funcBody = 'data = data || {}; return ' + result.join(' + ') + ';';
   return new Function('data', funcBody);
 }

--- a/src/template.js
+++ b/src/template.js
@@ -2,10 +2,12 @@
  * Parse format string and return object
  *
  * @param {String} format format string
+ * @param {Object} meta meta data
  */
-export default function (format) {
+export default function (format, meta) {
   const regex = /\{\{(\w+)\}\}/g;
   const result = [];
+  meta = meta || {};
 
   if (!format || (typeof format !== 'string' &&  !(format instanceof String))) {
     return new Function('data', 'return \'\';');
@@ -18,8 +20,7 @@ export default function (format) {
     if (index + length < match.index) {
       result.push('\'' + format.substring(index + length, match.index) + '\'');
     }
-    //fast check for a function: !!(object && object.constructor && object.call && object.apply) 
-    result.push('((!!(data.' + match[1] + ' && data.' + match[1] + '.constructor && data.' + match[1] + '.call && data.' + match[1] + '.apply) ? data.' + match[1] + '() : data.' + match[1] + ') || \'' + match[0] + '\')');
+    result.push('(' + (isFunction(meta[match[1]]) ? ('data.' + match[1] + '()') : ('data.' + match[1])) + ' || \'' + match[0] + '\')');
 
     index = match.index;
     length = match[0].length;
@@ -30,4 +31,8 @@ export default function (format) {
 
   const funcBody = 'data = data || {}; return ' + result.join(' + ') + ';';
   return new Function('data', funcBody);
+}
+
+function isFunction(object) {
+  return !!(object && object.constructor && object.call && object.apply);
 }

--- a/src/template.js
+++ b/src/template.js
@@ -3,7 +3,7 @@
  *
  * @param {String} format format string
  */
-exports.parse = function (format) {
+export default function (format) {
   let regex = /\$\{(\w+)\}/g;
   let result = [];
 
@@ -12,33 +12,17 @@ exports.parse = function (format) {
   let match;
   while (match = regex.exec(format)) {
     if (index + length < match.index) {
-      result.push({type: 'text', value: format.substring(index + length, match.index)});
+      result.push('\'' + format.substring(index + length, match.index) + '\'');
     }
-    result.push({type: 'key', key: match[1], value: match[0]});
+    result.push('(data.' + match[1] + ' || \'' + match[0] + '\')');
 
     index = match.index;
     length = match[0].length;
   }
   if ((index + length) < format.length) {
-    result.push({type: 'text', value: format.substring(index + length, format.length)});
+    result.push('\'' + format.substring(index + length, format.length) + '\'');
   }
-  return result;
-}
 
-/**
- * Parse format string and return object
- *
- * @param {String} parsed parsed format string
- * @param {Object} data metadata
- */
-exports.resolve = function (parsed, data) {
-  let result = '';
-  parsed.forEach(function (el) {
-    if (el.type === 'key') {
-      result += data[el.key] || el.value;
-    } else {
-      result += el.value;
-    }
-  });
-  return result;
+  let funcBody = 'return ' + result.join(' + ') + ';';
+  return new Function('data', funcBody);
 }

--- a/test/template-test.js
+++ b/test/template-test.js
@@ -8,7 +8,7 @@ describe('template', () => {
       return 1 + 2;
     };
     const data = {timestamp: new Date().toISOString(), calculatedValue: func, namespace: 'class', level: 'INFO', data: 'Hello World'};
-    const compiled = template(format);
+    const compiled = template(format, data);
     const str = compiled(data);
     str.should.be.equal(data.timestamp + ' ' + func() + ' (' + data.namespace + ') ' + data.level + ': ' + data.data);
   });
@@ -16,7 +16,7 @@ describe('template', () => {
   it('should replace all variables if format is instanceof String', () => {
     const format = new String('{{timestamp}} ({{namespace}}) {{level}}: {{data}}');
     const data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO', data: 'Hello World'};
-    const compiled = template(format);
+    const compiled = template(format, data);
     const str = compiled(data);
     str.should.be.equal(data.timestamp + ' (' + data.namespace + ') ' + data.level + ': ' + data.data);
   });
@@ -24,7 +24,7 @@ describe('template', () => {
   it('should keep placeholder if variable is undefined', () => {
     const format = '{{timestamp}} ({{namespace}}) {{level}}: {{data}}';
     const data = {timestamp: new Date().toISOString(), level: 'INFO', data: 'Hello World'};
-    const compiled = template(format);
+    const compiled = template(format, data);
     const str = compiled(data);
     str.should.be.equal(data.timestamp + ' ({{namespace}}) ' + data.level + ': ' + data.data);
   });
@@ -32,7 +32,7 @@ describe('template', () => {
   it('should preserve trailing whitespace', () => {
     const format = 'Message: {{timestamp}} ({{namespace}}) {{level}}: ';
     const data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
-    const compiled = template(format);
+    const compiled = template(format, data);
     const str = compiled(data);
     str.should.be.equal('Message: ' + data.timestamp + ' (' + data.namespace + ') ' + data.level + ': ');    
   });
@@ -40,7 +40,7 @@ describe('template', () => {
   it('should return format string if no literals', () => {
     const format = 'Message: {{ Hellow world}';
     const data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
-    const compiled = template(format);
+    const compiled = template(format, data);
 
     let str = compiled(data);
     str.should.be.equal('Message: {{ Hellow world}');   

--- a/test/template-test.js
+++ b/test/template-test.js
@@ -2,36 +2,79 @@ import template from '../src/template'
 
 
 describe('template', () => {
-  it('execute', (done) => {
-    let format = '${timestamp} (${namespace}) ${level}: ${data}';
-    let data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO', data: 'Hello World'};
-    let compiled = template(format);
-
-    let str = compiled(data);
+  it('should replace all variables or functions', () => {
+    const format = '{{timestamp}} {{calculatedValue}} ({{namespace}}) {{level}}: {{data}}';
+    const func = () =>  {
+      return 1 + 2;
+    };
+    const data = {timestamp: new Date().toISOString(), calculatedValue: func, namespace: 'class', level: 'INFO', data: 'Hello World'};
+    const compiled = template(format);
+    const str = compiled(data);
+    str.should.be.equal(data.timestamp + ' ' + func() + ' (' + data.namespace + ') ' + data.level + ': ' + data.data);
+  });
+  
+  it('should replace all variables if format is instanceof String', () => {
+    const format = new String('{{timestamp}} ({{namespace}}) {{level}}: {{data}}');
+    const data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO', data: 'Hello World'};
+    const compiled = template(format);
+    const str = compiled(data);
     str.should.be.equal(data.timestamp + ' (' + data.namespace + ') ' + data.level + ': ' + data.data);
-    
-    delete data['namespace'];
-    str = compiled(data);
-    str.should.be.equal(data.timestamp + ' (${namespace}) ' + data.level + ': ' + data.data);
-    
-    done();
-  })
-  it('execute extended format', (done) => {
-    let format = 'Message: ${timestamp} (${namespace}) ${level}: ';
-    let data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
-    let compiled = template(format);
-
-    let str = compiled(data);
+  });
+  
+  it('should keep placeholder if variable is undefined', () => {
+    const format = '{{timestamp}} ({{namespace}}) {{level}}: {{data}}';
+    const data = {timestamp: new Date().toISOString(), level: 'INFO', data: 'Hello World'};
+    const compiled = template(format);
+    const str = compiled(data);
+    str.should.be.equal(data.timestamp + ' ({{namespace}}) ' + data.level + ': ' + data.data);
+  });
+  
+  it('should preserve trailing whitespace', () => {
+    const format = 'Message: {{timestamp}} ({{namespace}}) {{level}}: ';
+    const data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
+    const compiled = template(format);
+    const str = compiled(data);
     str.should.be.equal('Message: ' + data.timestamp + ' (' + data.namespace + ') ' + data.level + ': ');    
-    done();
-  })
-  it('execute with no literals', (done) => {
-    let format = 'Message: Hellow world';
-    let data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
-    let compiled = template(format);
+  });
+  
+  it('should return format string if no literals', () => {
+    const format = 'Message: {{ Hellow world}';
+    const data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
+    const compiled = template(format);
 
     let str = compiled(data);
-    str.should.be.equal('Message: Hellow world');    
-    done();
-  })
+    str.should.be.equal('Message: {{ Hellow world}');   
+  });
+  
+  it('should return format string if no data', () => {
+    const format = '{{timestamp}} ({{namespace}}) {{level}}:';
+    const compiled = template(format);
+
+    let str = compiled({});
+    str.should.be.equal('{{timestamp}} ({{namespace}}) {{level}}:');  
+    
+    str = compiled();
+    str.should.be.equal('{{timestamp}} ({{namespace}}) {{level}}:');  
+  });
+  
+  it('should return empty string if format is undefined or empty or not a string', () => {
+    const format = 'Message: Hellow world';
+    const data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
+
+    let compiled = template();
+    let str = compiled(data);
+    str.should.be.equal('');    
+
+    compiled = template('');
+    str = compiled(data);
+    str.should.be.equal('');  
+
+    compiled = template({});
+    str = compiled(data);
+    str.should.be.equal('');  
+
+    compiled = template(() => {});
+    str = compiled(data);
+    str.should.be.equal('');  
+  });
 })

--- a/test/template-test.js
+++ b/test/template-test.js
@@ -1,0 +1,28 @@
+import template from '../src/template'
+
+
+describe('template', () => {
+  it('parse and resolve', (done) => {
+    let format = '${timestamp} (${namespace}) ${level}: ${data}';
+    let data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO', data: 'Hello World'};
+    let parsed = template.parse(format);
+
+    let str = template.resolve(parsed, data);
+    str.should.be.equal(data.timestamp + ' (' + data.namespace + ') ' + data.level + ': ' + data.data);
+    
+    delete data['namespace'];
+    str = template.resolve(parsed, data);
+    str.should.be.equal(data.timestamp + ' (${namespace}) ' + data.level + ': ' + data.data);
+    
+    done();
+  })
+  it('parse and resolve extended format', (done) => {
+    let format = 'Message: ${timestamp} (${namespace}) ${level}: ';
+    let data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
+    let parsed = template.parse(format);
+
+    let str = template.resolve(parsed, data);
+    str.should.be.equal('Message: ' + data.timestamp + ' (' + data.namespace + ') ' + data.level + ': ');    
+    done();
+  })
+})

--- a/test/template-test.js
+++ b/test/template-test.js
@@ -2,27 +2,36 @@ import template from '../src/template'
 
 
 describe('template', () => {
-  it('parse and resolve', (done) => {
+  it('execute', (done) => {
     let format = '${timestamp} (${namespace}) ${level}: ${data}';
     let data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO', data: 'Hello World'};
-    let parsed = template.parse(format);
+    let compiled = template(format);
 
-    let str = template.resolve(parsed, data);
+    let str = compiled(data);
     str.should.be.equal(data.timestamp + ' (' + data.namespace + ') ' + data.level + ': ' + data.data);
     
     delete data['namespace'];
-    str = template.resolve(parsed, data);
+    str = compiled(data);
     str.should.be.equal(data.timestamp + ' (${namespace}) ' + data.level + ': ' + data.data);
     
     done();
   })
-  it('parse and resolve extended format', (done) => {
+  it('execute extended format', (done) => {
     let format = 'Message: ${timestamp} (${namespace}) ${level}: ';
     let data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
-    let parsed = template.parse(format);
+    let compiled = template(format);
 
-    let str = template.resolve(parsed, data);
+    let str = compiled(data);
     str.should.be.equal('Message: ' + data.timestamp + ' (' + data.namespace + ') ' + data.level + ': ');    
+    done();
+  })
+  it('execute with no literals', (done) => {
+    let format = 'Message: Hellow world';
+    let data = {timestamp: new Date().toISOString(), namespace: 'class', level: 'INFO'};
+    let compiled = template(format);
+
+    let str = compiled(data);
+    str.should.be.equal('Message: Hellow world');    
     done();
   })
 })


### PR DESCRIPTION
@nemtsov please review and let me know if you have any remarks.
Decided to leave the message data out of the format string in order to let console methods handle it.
As far as performance go my tests show that this implementation is slightly faster  than the current one.